### PR TITLE
Add meta.ref when dereferencing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 1.2.0 - 2016-02-02
+
+- Add reference information to dereferenced data structures via the `meta.ref` property, which contains a string ID of the reference from which the element is derived. This works for both type references and object mixins/includes.
+
 # 1.1.0 - 2016-02-01
 
 - Expose a `dereference` function. Both the example and schema generators now use this internally to simplify their specific code.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ let schema = eidolon.schema(input);
 
 ### `eidolon.dereference(input, [dataStructures])`
 
-Dereference an input element or structure of elements with the given data structures. This will return the same element or structure with resolved references so you do not have to handle inheritance or object includes.
+Dereference an input element or structure of elements with the given data structures. This will return the same element or structure with resolved references so you do not have to handle inheritance or object includes. Each resolved reference will include the name of the referenced type or mixin in the [`meta.ref` property](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md#properties).
 
 ```js
 import eidolon from 'eidolon';
@@ -180,8 +180,9 @@ const dataStructures = {
 
 let dereferenced = eidolon.dereference(input, dataStructures);
 
-console.log(dereferenced.element); // => 'string'
-console.log(dereferenced.content); // => 'Hello, world!'
+console.log(dereferenced.element);  // => 'string'
+console.log(dereferenced.content);  // => 'Hello, world!'
+console.log(dereferenced.meta.ref); // => 'MyString'
 ```
 
 ### `eidolon.inherit(base, element)`

--- a/src/dereference.coffee
+++ b/src/dereference.coffee
@@ -26,8 +26,14 @@ module.exports = dereference = (root, dataStructures) ->
         member = properties[i]
         i++
         if member.element == 'ref'
-          ref = dataStructures[member.content.href]
           i--
+          ref = dataStructures[member.content.href]
+          # Create a deep copy of the contents and set a reference on each
+          # member, so we know where it came from.
+          ref.content = JSON.parse JSON.stringify(ref.content)
+          for property in ref.content
+            property.meta ?= {}
+            property.meta.ref = member.content.href
           # Here we need to transclude the content - we may be including any
           # number of elements from the parent, and each of these must be
           # processed to dereference it (if needed).

--- a/src/inherit.coffee
+++ b/src/inherit.coffee
@@ -28,9 +28,14 @@ module.exports = (base, element) ->
   combined = JSON.parse(JSON.stringify(base))
 
   # Next, we copy or overwrite any metadata and attributes
+  if base.meta?.id?
+    delete combined.meta.id
+    combined.meta.ref = base.meta.id
+
   if element.meta
     combined.meta ?= {}
     combined.meta[key] = value for own key, value of element.meta
+
   if element.attributes
     combined.attributes ?= {}
     combined.attributes[key] = value for own key, value of element.attributes

--- a/test/eidolon.coffee
+++ b/test/eidolon.coffee
@@ -66,9 +66,13 @@ describe 'Dereferencing', ->
   dataStructures =
     FooType:
       element: 'number'
+      meta:
+        id: 'FooType'
       content: 5
     BarType:
       element: 'object'
+      meta:
+        id: 'BarType'
       content: [
         element: 'member'
         content:
@@ -90,9 +94,13 @@ describe 'Dereferencing', ->
             content: 'foo'
           value:
             element: 'number'
+            meta:
+              ref: 'FooType'
             content: 5
       ,
         element: 'member'
+        meta:
+          ref: 'BarType'
         content:
           key:
             element: 'string'


### PR DESCRIPTION
This uses Refract's `meta.ref` property to set the ID (as a string) of the referenced type when dereferencing. This means that both inheritance and mixins/includes can be traced back to their original source after dereferencing a data structure.

cc @Baggz 
