### PR TITLE
Add missing ref data to inherited members

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 1.2.2 - 2016-02-23
+
+- Add missing `ref` data to inherited members.
+
 # 1.2.1 - 2016-02-16
 
 - Fix crash when handling objects or references to objects with no content.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidolon",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Generate JSON or JSON Schema from Refract & MSON data structures",
   "main": "lib/eidolon.js",
   "scripts": {

--- a/src/inherit.coffee
+++ b/src/inherit.coffee
@@ -32,6 +32,14 @@ module.exports = (base, element) ->
     delete combined.meta.id
     combined.meta.ref = base.meta.id
 
+    # Also, set individual member ref info, but only if it isn't already set!
+    if combined.content?.length
+      for item in combined.content
+        if item.element
+          unless item.meta and item.meta.ref
+            item.meta ?= {}
+            item.meta.ref = base.meta.id
+
   if element.meta
     combined.meta ?= {}
     combined.meta[key] = value for own key, value of element.meta

--- a/test/eidolon.coffee
+++ b/test/eidolon.coffee
@@ -94,6 +94,8 @@ describe 'Dereferencing', ->
       ref: 'MyType'
     content: [
         element: 'member'
+        meta:
+          ref: 'MyType'
         content:
           key:
             element: 'string'
@@ -116,6 +118,8 @@ describe 'Dereferencing', ->
             content: 'Hello'
       ,
         element: 'member'
+        meta:
+          ref: 'MyType'
         content:
           key:
             element: 'string'


### PR DESCRIPTION
This fixes #3. The feature was working for includes/mixins, but was missing for members added through the `inherit` function. I tested a lot of variations and believe this should work well, even when the inherited base class is inheriting another class. Please let me know if you can think of any case where the code might break down! Version is bumped for a bug fix release.

cc @Baggz 
