### PR TITLE
Add origin link relations for inheritance/includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ let merged = eidolon.inherit(base, element);
 // Merged now looks like:
 {
   element: 'number',
+  meta: {
+    ref: 'NullableNumber',
+    links: [
+      {
+        relation: 'origin',
+        href: 'http://refract.link/inherited/'
+      }
+    ]
+  },
   attributes: {
     default: 2,
     typeAttributes: ['nullable']

--- a/src/dereference.coffee
+++ b/src/dereference.coffee
@@ -34,6 +34,10 @@ module.exports = dereference = (root, dataStructures) ->
           for property in ref.content
             property.meta ?= {}
             property.meta.ref = member.content.href
+            property.meta.links ?= []
+            property.meta.links.push
+              relation: 'origin'
+              href: 'http://refract.link/included-member/'
           # Here we need to transclude the content - we may be including any
           # number of elements from the parent, and each of these must be
           # processed to dereference it (if needed).

--- a/src/inherit.coffee
+++ b/src/inherit.coffee
@@ -31,6 +31,10 @@ module.exports = (base, element) ->
   if base.meta?.id?
     delete combined.meta.id
     combined.meta.ref = base.meta.id
+    combined.meta.links ?= []
+    combined.meta.links.push
+      relation: 'origin'
+      href: 'http://refract.link/inherited/'
 
     # Also, set individual member ref info, but only if it isn't already set!
     if combined.content?.length
@@ -39,6 +43,10 @@ module.exports = (base, element) ->
           unless item.meta and item.meta.ref
             item.meta ?= {}
             item.meta.ref = base.meta.id
+            item.meta.links ?= []
+            item.meta.links.push
+              relation: 'origin'
+              href: 'http://refract.link/inherited-member/'
 
   if element.meta
     combined.meta ?= {}

--- a/test/eidolon.coffee
+++ b/test/eidolon.coffee
@@ -92,10 +92,22 @@ describe 'Dereferencing', ->
     element: 'object'
     meta:
       ref: 'MyType'
+      links: [
+        {
+          relation: 'origin'
+          href: 'http://refract.link/inherited/'
+        }
+      ]
     content: [
         element: 'member'
         meta:
           ref: 'MyType'
+          links: [
+            {
+              relation: 'origin'
+              href: 'http://refract.link/inherited-member/'
+            }
+          ]
         content:
           key:
             element: 'string'
@@ -104,11 +116,23 @@ describe 'Dereferencing', ->
             element: 'number'
             meta:
               ref: 'FooType'
+              links: [
+                {
+                  relation: 'origin'
+                  href: 'http://refract.link/inherited/'
+                }
+              ]
             content: 5
       ,
         element: 'member'
         meta:
           ref: 'BarType'
+          links: [
+            {
+              relation: 'origin'
+              href: 'http://refract.link/included-member/'
+            }
+          ]
         content:
           key:
             element: 'string'
@@ -120,6 +144,12 @@ describe 'Dereferencing', ->
         element: 'member'
         meta:
           ref: 'MyType'
+          links: [
+            {
+              relation: 'origin'
+              href: 'http://refract.link/inherited-member/'
+            }
+          ]
         content:
           key:
             element: 'string'


### PR DESCRIPTION
Each inherited element, member, and included member will have their own `origin` link relation with this change. Please let me know what you think of this approach and the link `href`s I've come up with. Currently they just redirect to the relevant sections of the Refract specification, but in the future we can do whatever we want with them.

cc @Baggz @smizell
