### PR TITLE
Handle circular references

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 1.5.0 - 2016-03-25
+
+- Handle circular references when dereferencing, by stopping processing and adding in a circular reference origin link relation.
+
 # 1.4.0 - 2016-03-02
 
 - Generate smart random data when elements have no sample or default value set. This can now be overridden with your own `defaultValue` function.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidolon",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Generate JSON or JSON Schema from Refract & MSON data structures",
   "main": "lib/eidolon.js",
   "scripts": {

--- a/src/example.coffee
+++ b/src/example.coffee
@@ -47,6 +47,12 @@ generateExample = (root, context) ->
         context.path.pop()
         if root.meta?.id then context.path.pop()
       obj
+    else
+      # This could return either `null` or `undefined`... not sure which
+      # is best. Null means it will be serialized to JSON to show e.g.
+      # the key name. For example: {'keyName': null} vs. {}. The downside
+      # is that `null` may not actually be allowed.
+      null
 
 module.exports = (root, dataStructures, options) ->
   options ?= {}

--- a/src/inherit.coffee
+++ b/src/inherit.coffee
@@ -9,6 +9,8 @@
 # # Another Type (My Type)
 # + id (string)
 
+{createLink} = require './util'
+
 # Make sure all members are unique, removing all duplicates before the last
 # occurence of the member key name.
 uniqueMembers = (content) ->
@@ -39,8 +41,7 @@ inherit = (base, element) ->
   if base.meta?.id?
     delete combined.meta.id
     combined.meta.ref = base.meta.id
-    combined.meta.links ?= []
-    combined.meta.links.push
+    createLink combined,
       relation: 'origin'
       href: 'http://refract.link/inherited/'
 
@@ -49,12 +50,10 @@ inherit = (base, element) ->
       for item in combined.content
         if item.element
           unless item.meta and item.meta.ref
-            item.meta ?= {}
-            item.meta.ref = base.meta.id
-            item.meta.links ?= []
-            item.meta.links.push
+            createLink item,
               relation: 'origin'
               href: 'http://refract.link/inherited-member/'
+            item.meta.ref = base.meta.id
 
   if element.meta
     combined.meta ?= {}

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -1,0 +1,8 @@
+# Utility functions
+
+# Create a new link in an element's metadata. This creates `meta` and
+# `meta.links` if needed.
+exports.createLink = (element, link) ->
+  element.meta ?= {}
+  element.meta.links ?= []
+  element.meta.links.push link

--- a/test/fixtures/circular-example.json
+++ b/test/fixtures/circular-example.json
@@ -1,0 +1,9 @@
+{
+  "assets": [
+    {
+      "address": {
+        "owner": null
+      }
+    }
+  ]
+}

--- a/test/fixtures/circular-refract.json
+++ b/test/fixtures/circular-refract.json
@@ -1,0 +1,7 @@
+{
+  "element": "Person",
+  "meta": {
+    "id": "Customer"
+  },
+  "content": []
+}

--- a/test/fixtures/circular-schema.json
+++ b/test/fixtures/circular-schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "assets": {
+      "items": {
+        "properties": {
+          "address": {
+            "properties": {
+              "owner": {}
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/test/fixtures/circular-structures.json
+++ b/test/fixtures/circular-structures.json
@@ -1,0 +1,69 @@
+{
+  "Person": {
+    "element": "object",
+    "meta": {
+      "id": "Person"
+    },
+    "content": [
+      {
+        "element": "member",
+        "content": {
+          "key": {
+            "element": "string",
+            "content": "assets"
+          },
+          "value": {
+            "element": "array",
+            "content": [
+              {
+                "element": "Asset"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Asset": {
+    "element": "object",
+    "meta": {
+      "id": "Asset"
+    },
+    "content": [
+      {
+        "element": "member",
+        "content": {
+          "key": {
+            "element": "string",
+            "content": "address"
+          },
+          "value": {
+            "element": "Address",
+            "content": []
+          }
+        }
+      }
+    ]
+  },
+  "Address": {
+    "element": "object",
+    "meta": {
+      "id": "Address"
+    },
+    "content": [
+      {
+        "element": "member",
+        "content": {
+          "key": {
+            "element": "string",
+            "content": "owner"
+          },
+          "value": {
+            "element": "Person",
+            "content": []
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
First pass at handling circular references when dereferencing, generating examples, and generating schemas. The examples and schemas could use more work but nothing infinitely loops anymore.

This adds a new `origin` link relation with `href` set to http://refract.link/circular-reference/ so you can detect circular refs. Please let me know if you need any other info attached to the elements!

cc @Baggz, feel free to merge & release if this looks good.
