### PR TITLE
Add a missing license file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 1.5.4
+
+- Adds a LICENSE file to the project.
+
 # 1.5.3
 
 - Allow meta.id to be an object for the datastructure.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright © 2018 Daniel G. Taylor <danielgtaylor@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidolon",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Generate JSON or JSON Schema from Refract & MSON data structures",
   "main": "lib/eidolon.js",
   "scripts": {


### PR DESCRIPTION
The MIT license states the following:

> The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

Which renders the NPM package as unlicensed as it is packaged to NPM public repository without a LICENSE file and thus without the copyright and permission notice thus voiding the license.

