### PR TITLE
Use released faker 3.1.0 instead of a commit-hash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidolon",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "Generate JSON or JSON Schema from Refract & MSON data structures",
   "main": "lib/eidolon.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "sinon": "^1.17.3"
   },
   "dependencies": {
-    "faker": "github:marak/faker.js#9bb2b7c"
+    "faker": "^3.1.0"
   }
 }


### PR DESCRIPTION
Never versions of `npm` (5.6+ and 6.4+) have some crazy problems with versions of packages not being written in one format (either a whole URL to the `GH repository`, or just a `semver-number`)

I'm offering a compatible `faker`-version to be used by `eidolon` here. Please do merge & release. Thanks.